### PR TITLE
Fix build with -Wformat-security

### DIFF
--- a/src/Credit/ModuleWriter.hpp
+++ b/src/Credit/ModuleWriter.hpp
@@ -111,7 +111,7 @@ struct ModuleWriter {
 
         for(const auto& p : plugins) {
             auto pStr = p.print(writeURLs, pluginNamesOnly, allCaps);
-            fprintf(file, pStr.c_str());
+            fprintf(file, "%s", pStr.c_str());
         }
     }
 };


### PR DESCRIPTION
printf-related functions without format string are a security issue, so a few systems have that as an error by default, thus breaking the build.

```
In file included from ChowDSP/src/Credit/Credit.cpp:4:
ChowDSP/src/Credit/ModuleWriter.hpp: In member function ‘void ModuleWriter::operator()(FILE*)’:
ChowDSP/src/Credit/ModuleWriter.hpp:114:20: error: format not a string literal and no format arguments [-Werror=format-security]
  114 |             fprintf(file, pStr.c_str());
```

This patch fixes the issue.
We could alternatively use `fputs` but that places a newline at the end, which is not always wanted.