### PR TITLE
Fix delete/free inconsistency and adjust file browser for cardinal

### DIFF
--- a/src/Credit/Credit.cpp
+++ b/src/Credit/Credit.cpp
@@ -28,18 +28,34 @@ struct CreditWidget : ModuleWidget {
     ModuleWriter mWriter;
 
     static void saveModules(ModuleWriter& mWriter) {
-        auto pathC = file_utils::getChosenFilePath();
+#ifdef USING_CARDINAL_NOT_RACK
+        std::string dir, ignore;
+        file_utils::getDefaultFilePath(dir, ignore);
+        async_dialog_filebrowser(true, dir.c_str(), "Save credit file", [&mWriter](char* pathC) {
+            if (pathC == nullptr) {
+                return; // fail silently
+            }
+            saveModulesPath(mWriter, pathC);
+            std::free(pathC);
+        });
+#else
+        char* pathC = file_utils::getChosenFilePath();
         if (pathC == nullptr) {
             return; // fail silently
         }
+        saveModulesPath(mWriter, pathC);
+        std::free(pathC);
+#endif
+    }
 
+    static void saveModulesPath(ModuleWriter& mWriter, const char* pathC) {
 	    // Append .txt extension if no extension was given.
-	    std::string pathStr = pathC.get();
+	    std::string pathStr = pathC;
 	    if (system::getExtension(pathStr) == "") {
 	    	pathStr += ".txt";
 	    }
 
-	    file_utils::FilePtr file = file_utils::getFilePtr(pathC.get());
+	    file_utils::FilePtr file = file_utils::getFilePtr(pathC);
 	    if (file == nullptr) {
 	    	return; // Fail silently
         }

--- a/src/Credit/FileUtils.hpp
+++ b/src/Credit/FileUtils.hpp
@@ -20,7 +20,7 @@ void getDefaultFilePath (std::string& dir, std::string& filename) {
 }
 
 /** Opens a dialog window to retrieve a file path to save to */
-std::unique_ptr<char> getChosenFilePath() {
+char* getChosenFilePath() {
     std::string dir;
     std::string filename;
     getDefaultFilePath(dir, filename);
@@ -30,12 +30,10 @@ std::unique_ptr<char> getChosenFilePath() {
         filename += ".txt";
     }
 
-    std::unique_ptr<char> pathC;
-
     auto* filters = osdialog_filters_parse("Raw Text (.txt):txt,m;Markdown (.md):md");
-    pathC.reset(osdialog_file(OSDIALOG_SAVE, dir.c_str(), filename.c_str(), NULL));
+    char* pathC = osdialog_file(OSDIALOG_SAVE, dir.c_str(), filename.c_str(), NULL);
     osdialog_filters_free(filters);
-        
+
     return pathC;
 }
 


### PR DESCRIPTION
Your file utils are using `std::unique_ptr` which uses C++ new/delete operations behind the scenes.
The value returned by `osdialog_file` is a C-style `malloc` pointer, which needs the C-style `free` call.
Mismatch of new/delete with malloc/free can cause crashes.
This PR fixes it, so that we use the correct `free` call.

Additionally the file browser stuff is also patched to work in Cardinal, where I do not allow osdialog as it blocks the host event loop (IMO that is very bad practice).
