### PR TITLE
Refactor FileUtils to fix delete/free inconsistency, and support async file dialogs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ include $(RACK_DIR)/arch.mk
 # FLAGS will be passed to both the C and C++ compiler
 FLAGS += -Ilib -Ilib/chowdsp_utils/modules/chowdsp_dsp/WDF -DUSE_EIGEN
 CFLAGS +=
-CXXFLAGS +=
+CXXFLAGS += -Wno-c++17-extensions -Wno-c++14-extensions
 
 # Careful about linking to shared libraries, since you can't assume much about the user's environment and library search path.
 # Static libraries are fine, but they should be added to this plugin's build system.
@@ -26,9 +26,6 @@ include $(RACK_DIR)/plugin.mk
 
 # Eigen library has a ton of deprecated copy warnings
 CXXFLAGS += -Wno-deprecated-copy
-
-# WDF library uses nested namespaces (C++17 extension)
-CXXFLAGS += -Wno-c++17-extensions
 
 ifdef ARCH_WIN
 # extra dist target for Azure CI Windows build, as there is only 7zip available and no zip command

--- a/src/Credit/FileUtils.hpp
+++ b/src/Credit/FileUtils.hpp
@@ -48,7 +48,7 @@ void saveToChosenFilePath (std::function<void(const char* path)>&& saveAction) {
     });
 #else
     osdialog_filters_ptr filters { osdialog_filters_parse("Raw Text (.txt):txt,m;Markdown (.md):md"), osdialog_filters_free };
-    osdialog_file_ptr path { osdialog_file(OSDIALOG_SAVE, dir.c_str(), filename.c_str(), nullptr), std::free };
+    osdialog_file_ptr path { osdialog_file(OSDIALOG_SAVE, dir.c_str(), filename.c_str(), filters.get()), std::free };
     saveAction(path.get());
 #endif
 }

--- a/src/Credit/FileUtils.hpp
+++ b/src/Credit/FileUtils.hpp
@@ -42,10 +42,10 @@ void saveToChosenFilePath (std::function<void(const char* path)>&& saveAction) {
 #ifdef USING_CARDINAL_NOT_RACK
     // Cardinal currently requires us to use their async_dialog_filebrowser in place of
     // osdialog_file, since osdialog_file blocks the event loop.
-    async_dialog_filebrowser(true, dir.c_str(), "Save credit file", [action = std::move (saveAction)](char* path) {
-        action (path);
-        std::free(path);
-    });
+    async_dialog_filebrowser(true, dir.c_str(), "Save credit file", std::bind ([](decltype(saveAction)&& action, char* path) {
+                                action (path);
+                                std::free(path);
+                             }, std::move (saveAction), std::placeholders::_1));
 #else
     osdialog_filters_ptr filters { osdialog_filters_parse("Raw Text (.txt):txt,m;Markdown (.md):md"), osdialog_filters_free };
     osdialog_file_ptr path { osdialog_file(OSDIALOG_SAVE, dir.c_str(), filename.c_str(), filters.get()), std::free };

--- a/src/Credit/FileUtils.hpp
+++ b/src/Credit/FileUtils.hpp
@@ -6,6 +6,15 @@
 
 namespace file_utils {
 
+/** Smart pointer alias for the char array returned by osdialog_file */
+using osdialog_file_ptr = std::unique_ptr<char, decltype(&std::free)>;
+
+/** Smart pointer alias for osdialog_filters */
+using osdialog_filters_ptr = std::unique_ptr<osdialog_filters, decltype(&osdialog_filters_free)>;
+
+/** Smart pointer alias for a C file object */
+using FilePtr = std::unique_ptr<FILE, decltype(&std::fclose)>;
+
 /** Retrieve the default directory and file name for saving */
 void getDefaultFilePath (std::string& dir, std::string& filename) {
     auto path = APP->patch->path;
@@ -17,37 +26,40 @@ void getDefaultFilePath (std::string& dir, std::string& filename) {
     	dir = system::getDirectory(path);
     	filename = system::getFilename(path);
     }
+
+    if(system::getExtension(filename) == ".vcv") {
+      filename.erase(filename.end() - 4, filename.end());
+      filename += ".txt";
+    }
 }
 
-/** Opens a dialog window to retrieve a file path to save to */
-std::unique_ptr<char> getChosenFilePath() {
+/** Prompts the user to select a filepath to save to, and then performs the save action */
+void saveToChosenFilePath (std::function<void(const char* path)>&& saveAction) {
     std::string dir;
     std::string filename;
     getDefaultFilePath(dir, filename);
 
-    if(system::getExtension(filename) == ".vcv") {
-        filename.erase(filename.end() - 4, filename.end());
-        filename += ".txt";
-    }
-
-    std::unique_ptr<char> pathC;
-
-    auto* filters = osdialog_filters_parse("Raw Text (.txt):txt,m;Markdown (.md):md");
-    pathC.reset(osdialog_file(OSDIALOG_SAVE, dir.c_str(), filename.c_str(), NULL));
-    osdialog_filters_free(filters);
-        
-    return pathC;
+#ifdef USING_CARDINAL_NOT_RACK
+    // Cardinal currently requires us to use their async_dialog_filebrowser in place of
+    // osdialog_file, since osdialog_file blocks the event loop.
+    async_dialog_filebrowser(true, dir.c_str(), "Save credit file", [action = std::move (saveAction)](char* path) {
+        action (path);
+        std::free(path);
+    });
+#else
+    osdialog_filters_ptr filters { osdialog_filters_parse("Raw Text (.txt):txt,m;Markdown (.md):md"), osdialog_filters_free };
+    osdialog_file_ptr path { osdialog_file(OSDIALOG_SAVE, dir.c_str(), filename.c_str(), nullptr), std::free };
+    saveAction(path.get());
+#endif
 }
-
-using FilePtr = std::unique_ptr<FILE, decltype(&std::fclose)>;
 
 /** Returns a FilePtr to the file at the given path */
 FilePtr getFilePtr(std::string pathStr) {
-    if(system::getExtension(pathStr) == "") {
+    if(system::getExtension(pathStr).empty()) {
     	pathStr += ".txt";
     }
 
-	return { std::fopen(pathStr.c_str(), "w"), &std::fclose };
+    return { std::fopen(pathStr.c_str(), "w"), &std::fclose };
 }
 
 } // file_utils


### PR DESCRIPTION
Related to the changes discussed in #28.

This patch should probably be tested with Cardinal before merging (@falkTX).