### PR TITLE
RFC: Fix cardinal dialogs

### DIFF
--- a/src/Credit/FileUtils.hpp
+++ b/src/Credit/FileUtils.hpp
@@ -42,10 +42,10 @@ void saveToChosenFilePath (std::function<void(const char* path)>&& saveAction) {
 #ifdef USING_CARDINAL_NOT_RACK
     // Cardinal currently requires us to use their async_dialog_filebrowser in place of
     // osdialog_file, since osdialog_file blocks the event loop.
-    async_dialog_filebrowser(true, dir.c_str(), "Save credit file", std::bind ([](decltype(saveAction)&& action, char* path) {
-                                action (path);
-                                std::free(path);
-                             }, std::move (saveAction), std::placeholders::_1));
+    async_dialog_filebrowser(true, dir.c_str(), "Save credit file", [saveAction](char* path) {
+        saveAction (path);
+        std::free(path);
+    });
 #else
     osdialog_filters_ptr filters { osdialog_filters_parse("Raw Text (.txt):txt,m;Markdown (.md):md"), osdialog_filters_free };
     osdialog_file_ptr path { osdialog_file(OSDIALOG_SAVE, dir.c_str(), filename.c_str(), filters.get()), std::free };


### PR DESCRIPTION
I tested with this and module works, file is saved as expected.
Please have a look, does this seem ok to you?

I am not sure.. why do we need `std::bind` again?
